### PR TITLE
ite-829x-ui: fix RGB variable tests

### DIFF
--- a/ite-829x-ui
+++ b/ite-829x-ui
@@ -22,7 +22,7 @@ kblSave() {
 
 	leds=""
 	keys=({0..19} {32..43} {45..51} {64..83} {96..108} {110..115} 128 {130..147} {160..165} {169..179})
-	if [ "$red" != "" ] && [ "$red" != "" ] && [ "$blue" != "" ]; then
+	if [ "$red" != "" ] && [ "$green" != "" ] && [ "$blue" != "" ]; then
 		for key in ${keys[@]}; do
 			leds="${leds}led $key $red $green $blue\n"
 		done


### PR DESCRIPTION
Red was being tested twice while green was not being tested at all.