### PR TITLE
Shellcheck

### DIFF
--- a/ite-829x-ui
+++ b/ite-829x-ui
@@ -59,6 +59,7 @@ kblSet() {
 			-r | --red) red=${!j};;
 			-g | --green) green=${!j};;
 			-b | --blue) blue=${!j};;
+			*) exit 1;;
 		esac
 		i=$((i + 1));
 	done
@@ -102,6 +103,7 @@ kblToggle() {
 			-s | --speed) speeda=${!j};;
 			-e | --effect) effecta=${!j};;
 			-c | --color) color=${!j};;
+			*) exit 1;;
 		esac
 		i=$((i + 1));
 	done
@@ -246,6 +248,9 @@ do
 		;;
 		--gui)
 			guiMain
+		;;
+		*)
+			exit 1
 		;;
 	esac
 	i=$((i + 1));

--- a/ite-829x-ui
+++ b/ite-829x-ui
@@ -23,7 +23,7 @@ kblSave() {
 	leds=""
 	keys=({0..19} {32..43} {45..51} {64..83} {96..108} {110..115} 128 {130..147} {160..165} {169..179})
 	if [ "${red}" != "" ] && [ "${green}" != "" ] && [ "${blue}" != "" ]; then
-		for key in ${keys[@]}; do
+		for key in "${keys[@]}"; do
 			leds="${leds}led ${key} ${red} ${green} ${blue}\n"
 		done
 	fi
@@ -68,7 +68,7 @@ kblSet() {
 	leds=""
 	keys=({0..19} {32..43} {45..51} {64..83} {96..108} {110..115} 128 {130..147} {160..165} {169..179})
 	if [ "${red}" != "" ] && [ "${red}" != "" ] && [ "${blue}" != "" ]; then
-		for key in ${keys[@]}; do
+		for key in "${keys[@]}"; do
 			leds="${leds}led ${key} ${red} ${green} ${blue}\n"
 		done
 	fi
@@ -237,11 +237,11 @@ do
 			kblSet
 		;;
 		--set)
-			kblSet ${@}
+			kblSet "${@}"
 			kblSave
 		;;
 		--toggle)
-			kblToggle ${@}
+			kblToggle "${@}"
 			kblSave
 		;;
 		--gui)

--- a/ite-829x-ui
+++ b/ite-829x-ui
@@ -35,12 +35,12 @@ kblSave() {
 }
 
 kblLoad() {
-	brightnessspeed=$(cat "${configPath}${configFile}" | grep 'brightness+speed' | sed 's/brightness+speed//' | xargs)
+	brightnessspeed=$(grep 'brightness+speed' < "${configPath}${configFile}" | sed 's/brightness+speed//' | xargs)
 	IFS=' ' read -ra brightnessspeed <<< "${brightnessspeed}"
 	brightness="${brightnessspeed[0]}"
 	speed="${brightnessspeed[1]}"
-	effect=$(cat "${configPath}${configFile}" | grep 'effects' | sed 's/effects//' | xargs)
-	colorrgb=$(cat "${configPath}${configFile}" | grep 'led' | head -1 | sed 's/led//' | xargs)
+	effect=$(grep 'effects' < "${configPath}${configFile}" | sed 's/effects//' | xargs)
+	colorrgb=$(grep 'led' < "${configPath}${configFile}" | head -1 | sed 's/led//' | xargs)
 	IFS=' ' read -ra colorrgb <<< "${colorrgb}"
 	red="${colorrgb[1]}"
 	green="${colorrgb[2]}"

--- a/ite-829x-ui
+++ b/ite-829x-ui
@@ -31,20 +31,20 @@ kblSave() {
 
 	cfg="reset\nbrightness+speed ${brightness} ${speed}\neffects ${effect}\n${leds}"
 
-	echo -e ${cfg} > ${configPath}${configFile}
+	echo -e "${cfg}" > "${configPath}${configFile}"
 }
 
 kblLoad() {
-	brightnessspeed=$(cat ${configPath}${configFile} | grep 'brightness+speed' | sed 's/brightness+speed//' | xargs)
+	brightnessspeed=$(cat "${configPath}${configFile}" | grep 'brightness+speed' | sed 's/brightness+speed//' | xargs)
 	IFS=' ' read -ra brightnessspeed <<< "${brightnessspeed}"
-	brightness=${brightnessspeed[0]}
-	speed=${brightnessspeed[1]}
-	effect=$(cat ${configPath}${configFile} | grep 'effects' | sed 's/effects//' | xargs)
-	colorrgb=$(cat ${configPath}${configFile} | grep 'led' | head -1 | sed 's/led//' | xargs)
+	brightness="${brightnessspeed[0]}"
+	speed="${brightnessspeed[1]}"
+	effect=$(cat "${configPath}${configFile}" | grep 'effects' | sed 's/effects//' | xargs)
+	colorrgb=$(cat "${configPath}${configFile}" | grep 'led' | head -1 | sed 's/led//' | xargs)
 	IFS=' ' read -ra colorrgb <<< "${colorrgb}"
-	red=${colorrgb[1]}
-	green=${colorrgb[2]}
-	blue=${colorrgb[3]}
+	red="${colorrgb[1]}"
+	green="${colorrgb[2]}"
+	blue="${colorrgb[3]}"
 }
 
 kblSet() {
@@ -73,7 +73,7 @@ kblSet() {
 		done
 	fi
 
-	echo -e ${leds}
+	echo -e "${leds}"
 
 	if [ "${effect}" = "7" ]; then
 		cfg="reset\nbrightness+speed ${brightness} ${speed}\n"
@@ -82,12 +82,12 @@ kblSet() {
 	fi
 
 	if [ "${effect}" = "7" ]; then
-		sudo ${ite829x} << LEDs
-			$(echo -e ${cfg}${leds})
+		sudo "${ite829x}" << LEDs
+			$(echo -e "${cfg}${leds}")
 LEDs
 	else
-		sudo ${ite829x} << LEDs
-			$(echo -e ${cfg})
+		sudo "${ite829x}" << LEDs
+			$(echo -e "${cfg}")
 LEDs
 	fi
 }
@@ -146,17 +146,17 @@ kblToggle() {
 }
 
 guiBrightness() {
-	guiBrightness=$(zenity --scale --title "ite-829x brightness" --value ${brightness} --max-value=4 --min-value=0)
-	brightness=$([ "${guiBrightness}" != "" ] && echo ${guiBrightness} || echo ${brightness})
+	guiBrightness=$(zenity --scale --title "ite-829x brightness" --value "${brightness}" --max-value=4 --min-value=0)
+	brightness=$([ "${guiBrightness}" != "" ] && echo "${guiBrightness}" || echo "${brightness}")
 
-	kblSet -bs ${brightness}
+	kblSet -bs "${brightness}"
 }
 
 guiSpeed() {
-	guiSpeed=$(zenity --scale --title "ite-829x speed" --value ${speed} --max-value=3 --min-value=0)
-	speed=$([ "${guiSpeed}" != "" ] && echo ${guiSpeed} || echo ${speed})
+	guiSpeed=$(zenity --scale --title "ite-829x speed" --value "${speed}" --max-value=3 --min-value=0)
+	speed=$([ "${guiSpeed}" != "" ] && echo "${guiSpeed}" || echo "${speed}")
 
-	kblSet -s ${speed}
+	kblSet -s "${speed}"
 }
 
 guiEffect() {
@@ -170,20 +170,20 @@ guiEffect() {
 		"6" "Snake" \
 		"7" "Solid"
 	)
-	effect=$([ "${guiEffect}" != "" ] && echo ${guiEffect} || echo ${effect})
+	effect=$([ "${guiEffect}" != "" ] && echo "${guiEffect}" || echo "${effect}")
 
-	kblSet -e ${effect}
+	kblSet -e "${effect}"
 }
 
 guiColor() {
 	color=$(zenity --color-selection --title "ite-829x color" --color "rgb(${red},${green},${blue})" | sed 's/rgb(//' | sed 's/)//' | xargs)
 	if [ "${color}" != "" ]; then
 		IFS=',' read -ra color <<< "${color}"
-		red=${color[0]}
-		green=${color[1]}
-		blue=${color[2]}
+		red="${color[0]}"
+		green="${color[1]}"
+		blue="${color[2]}"
 
-		kblSet -e ${effect} -r ${red} -g ${green} -b ${blue}
+		kblSet -e "${effect}" -r "${red}" -g "${green}" -b "${blue}"
 	fi
 }
 
@@ -191,9 +191,9 @@ guiMain() {
 	effects=("Wave" "Breathe" "Scan" "Blink" "Random" "Ripple" "Snake" "Solid")
 
 	cmd=$(zenity --list --title "ite-829x GUI" --column='Property' --column='Value' \
-		"Brightness" ${brightness} \
-		"Speed" ${speed} \
-		"Effect" ${effects[${effect}]} \
+		"Brightness" "${brightness}" \
+		"Speed" "${speed}" \
+		"Effect" "${effects[${effect}]}" \
 		"Color" "${red}, ${green}, ${blue}" \
 		"Save" ""
 	)

--- a/ite-829x-ui
+++ b/ite-829x-ui
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ite829x=""
-configPath="/home/$USER/.local/share/"
+configPath="/home/${USER}/.local/share/"
 configFile="ite-829x.conf"
 
 ite829xFind() {
@@ -10,8 +10,8 @@ ite829xFind() {
 	elif [ "$(ls ite-829x)" != "" ]; then
 		ite829x="./ite-829x"
 	fi
-		
-	if [ "$ite829x" = "" ]; then
+
+	if [ "${ite829x}" = "" ]; then
 		echo "Unable to find ite-829x binaries"
 		exit 1
 	fi
@@ -22,26 +22,26 @@ kblSave() {
 
 	leds=""
 	keys=({0..19} {32..43} {45..51} {64..83} {96..108} {110..115} 128 {130..147} {160..165} {169..179})
-	if [ "$red" != "" ] && [ "$green" != "" ] && [ "$blue" != "" ]; then
+	if [ "${red}" != "" ] && [ "${green}" != "" ] && [ "${blue}" != "" ]; then
 		for key in ${keys[@]}; do
-			leds="${leds}led $key $red $green $blue\n"
+			leds="${leds}led ${key} ${red} ${green} ${blue}\n"
 		done
 	fi
 
 
-	cfg="reset\nbrightness+speed $brightness $speed\neffects $effect\n$leds"
+	cfg="reset\nbrightness+speed ${brightness} ${speed}\neffects ${effect}\n${leds}"
 
-	echo -e $cfg > ${configPath}${configFile}
+	echo -e ${cfg} > ${configPath}${configFile}
 }
 
 kblLoad() {
 	brightnessspeed=$(cat ${configPath}${configFile} | grep 'brightness+speed' | sed 's/brightness+speed//' | xargs)
-	IFS=' ' read -ra brightnessspeed <<< "$brightnessspeed"
+	IFS=' ' read -ra brightnessspeed <<< "${brightnessspeed}"
 	brightness=${brightnessspeed[0]}
 	speed=${brightnessspeed[1]}
 	effect=$(cat ${configPath}${configFile} | grep 'effects' | sed 's/effects//' | xargs)
 	colorrgb=$(cat ${configPath}${configFile} | grep 'led' | head -1 | sed 's/led//' | xargs)
-	IFS=' ' read -ra colorrgb <<< "$colorrgb"
+	IFS=' ' read -ra colorrgb <<< "${colorrgb}"
 	red=${colorrgb[1]}
 	green=${colorrgb[2]}
 	blue=${colorrgb[3]}
@@ -49,7 +49,7 @@ kblLoad() {
 
 kblSet() {
 	i=1;
-	for arg in "$@" 
+	for arg in "${@}"
 	do
 		j=$((i + 1))
 		case "${!i}" in
@@ -67,26 +67,26 @@ kblSet() {
 
 	leds=""
 	keys=({0..19} {32..43} {45..51} {64..83} {96..108} {110..115} 128 {130..147} {160..165} {169..179})
-	if [ "$red" != "" ] && [ "$red" != "" ] && [ "$blue" != "" ]; then
+	if [ "${red}" != "" ] && [ "${red}" != "" ] && [ "${blue}" != "" ]; then
 		for key in ${keys[@]}; do
-			leds="${leds}led $key $red $green $blue\n"
+			leds="${leds}led ${key} ${red} ${green} ${blue}\n"
 		done
 	fi
 
-	echo -e $leds
+	echo -e ${leds}
 
-	if [ "$effect" = "7" ]; then
-		cfg="reset\nbrightness+speed $brightness $speed\n"
+	if [ "${effect}" = "7" ]; then
+		cfg="reset\nbrightness+speed ${brightness} ${speed}\n"
 	else
-		cfg="reset\nbrightness+speed $brightness $speed\neffects $effect\n"
+		cfg="reset\nbrightness+speed ${brightness} ${speed}\neffects ${effect}\n"
 	fi
 
-	if [ "$effect" = "7" ]; then
-		sudo $ite829x << LEDs
+	if [ "${effect}" = "7" ]; then
+		sudo ${ite829x} << LEDs
 			$(echo -e ${cfg}${leds})
 LEDs
 	else
-		sudo $ite829x << LEDs
+		sudo ${ite829x} << LEDs
 			$(echo -e ${cfg})
 LEDs
 	fi
@@ -94,7 +94,7 @@ LEDs
 
 kblToggle() {
 	i=1;
-	for arg in "$@" 
+	for arg in "${@}"
 	do
 		j=$((i + 1))
 		case "${!i}" in
@@ -106,57 +106,57 @@ kblToggle() {
 		i=$((i + 1));
 	done
 
-	if [ "$brightnessa" = 'up' ] && [ "$brightness" != 4 ]; then
+	if [ "${brightnessa}" = 'up' ] && [ "${brightness}" != 4 ]; then
 		brightness=$((brightness + 1))
-	elif [ "$brightnessa" = 'down' ] && [ "$brightness" != 0 ]; then
+	elif [ "${brightnessa}" = 'down' ] && [ "${brightness}" != 0 ]; then
 		brightness=$((brightness - 1))
 	fi
 
-	if [ "$speeda" = 'up' ] && [ "$speed" < 3 ]; then
+	if [ "${speeda}" = 'up' ] && [ "${speed}" < 3 ]; then
 		speed=$((speed + 1))
-	elif [ "$speeda" = 'down' ] && [ "$speed" > 0 ]; then
+	elif [ "${speeda}" = 'down' ] && [ "${speed}" > 0 ]; then
 		speed=$((speed - 1))
-	elif [ "$speeda" = 'step' ] && [ "$speed" < 3 ]; then
+	elif [ "${speeda}" = 'step' ] && [ "${speed}" < 3 ]; then
 		speed=$((speed + 1))
-	elif [ "$speeda" = 'step' ] && [ "$speed" = 3 ]; then
+	elif [ "${speeda}" = 'step' ] && [ "${speed}" = 3 ]; then
 		speed=0
 	fi
 
-	if [ "$effecta" = 'rotate' ]; then
+	if [ "${effecta}" = 'rotate' ]; then
 		effect=$((effect + 1))
 
-		if [ "$effect" != 7 ]; then
+		if [ "${effect}" != 7 ]; then
 			reda=''
 			greena=''
 			bluea=''
 		else
-			reda=$red
-			greena=$green
-			bluea=$blue
+			reda=${red}
+			greena=${green}
+			bluea=${blue}
 		fi
 
-		if [ "$effect" = 8 ]; then
+		if [ "${effect}" = 8 ]; then
 			effect=0
 		fi
 	else
-		effect=$([ "$effecta" != "" ] && echo "$effecta" || echo "$effect")
+		effect=$([ "${effecta}" != "" ] && echo "${effecta}" || echo "${effect}")
 	fi
 
-	kblSet $([ "$brightness" != "" ] && echo "-bs $brightness") $([ "$speed" != "" ] && echo "-s $speed") $([ "$effect" != "" ] && echo "-e $effect") $([ "$reda" != "" ] && echo "-r $reda") $([ "$greena" != "" ] && echo "-g $greena") $([ "$bluea" != "" ] && echo "-b $bluea")
+	kblSet $([ "${brightness}" != "" ] && echo "-bs ${brightness}") $([ "${speed}" != "" ] && echo "-s ${speed}") $([ "${effect}" != "" ] && echo "-e ${effect}") $([ "${reda}" != "" ] && echo "-r ${reda}") $([ "${greena}" != "" ] && echo "-g ${greena}") $([ "${bluea}" != "" ] && echo "-b ${bluea}")
 }
 
 guiBrightness() {
-	guiBrightness=$(zenity --scale --title "ite-829x brightness" --value $brightness --max-value=4 --min-value=0)
-	brightness=$([ "$guiBrightness" != "" ] && echo $guiBrightness || echo $brightness)
+	guiBrightness=$(zenity --scale --title "ite-829x brightness" --value ${brightness} --max-value=4 --min-value=0)
+	brightness=$([ "${guiBrightness}" != "" ] && echo ${guiBrightness} || echo ${brightness})
 
-	kblSet -bs $brightness
+	kblSet -bs ${brightness}
 }
 
 guiSpeed() {
-	guiSpeed=$(zenity --scale --title "ite-829x speed" --value $speed --max-value=3 --min-value=0)
-	speed=$([ "$guiSpeed" != "" ] && echo $guiSpeed || echo $speed)
+	guiSpeed=$(zenity --scale --title "ite-829x speed" --value ${speed} --max-value=3 --min-value=0)
+	speed=$([ "${guiSpeed}" != "" ] && echo ${guiSpeed} || echo ${speed})
 
-	kblSet -s $speed
+	kblSet -s ${speed}
 }
 
 guiEffect() {
@@ -170,20 +170,20 @@ guiEffect() {
 		"6" "Snake" \
 		"7" "Solid"
 	)
-	effect=$([ "$guiEffect" != "" ] && echo $guiEffect || echo $effect)
+	effect=$([ "${guiEffect}" != "" ] && echo ${guiEffect} || echo ${effect})
 
-	kblSet -e $effect
+	kblSet -e ${effect}
 }
 
 guiColor() {
-	color=$(zenity --color-selection --title "ite-829x color" --color "rgb($red,$green,$blue)" | sed 's/rgb(//' | sed 's/)//' | xargs)
-	if [ "$color" != "" ]; then
-		IFS=',' read -ra color <<< "$color"
+	color=$(zenity --color-selection --title "ite-829x color" --color "rgb(${red},${green},${blue})" | sed 's/rgb(//' | sed 's/)//' | xargs)
+	if [ "${color}" != "" ]; then
+		IFS=',' read -ra color <<< "${color}"
 		red=${color[0]}
 		green=${color[1]}
 		blue=${color[2]}
 
-		kblSet -e $effect -r $red -g $green -b $blue
+		kblSet -e ${effect} -r ${red} -g ${green} -b ${blue}
 	fi
 }
 
@@ -191,14 +191,14 @@ guiMain() {
 	effects=("Wave" "Breathe" "Scan" "Blink" "Random" "Ripple" "Snake" "Solid")
 
 	cmd=$(zenity --list --title "ite-829x GUI" --column='Property' --column='Value' \
-		"Brightness" $brightness \
-		"Speed" $speed \
-		"Effect" ${effects[$effect]} \
-		"Color" "$red, $green, $blue" \
+		"Brightness" ${brightness} \
+		"Speed" ${speed} \
+		"Effect" ${effects[${effect}]} \
+		"Color" "${red}, ${green}, ${blue}" \
 		"Save" ""
 	)
 
-	case "$cmd" in
+	case "${cmd}" in
 		Brightness)
 			guiBrightness
 			guiMain
@@ -229,19 +229,19 @@ ite829xFind
 kblLoad
 
 i=1;
-for arg in "$@"
+for arg in "${@}"
 do
 	j=$((i + 1))
 	case "${!i}" in
 		--load)
 			kblSet
 		;;
-		--set) 
-			kblSet $@
+		--set)
+			kblSet ${@}
 			kblSave
 		;;
 		--toggle)
-			kblToggle $@
+			kblToggle ${@}
 			kblSave
 		;;
 		--gui)

--- a/ite-829x-ui
+++ b/ite-829x-ui
@@ -22,7 +22,7 @@ kblSave() {
 
 	leds=""
 	keys=({0..19} {32..43} {45..51} {64..83} {96..108} {110..115} 128 {130..147} {160..165} {169..179})
-	if [ "$red" != "" ] && [ "$red" != "" ] && [ "$blue" != "" ]; then
+	if [ "$red" != "" ] && [ "$green" != "" ] && [ "$blue" != "" ]; then
 		for key in ${keys[@]}; do
 			leds="${leds}led $key $red $green $blue\n"
 		done

--- a/ite-829x-ui
+++ b/ite-829x-ui
@@ -112,11 +112,11 @@ kblToggle() {
 		brightness=$((brightness - 1))
 	fi
 
-	if [ "${speeda}" = 'up' ] && [ "${speed}" < 3 ]; then
+	if [ "${speeda}" = 'up' ] && [ "${speed}" -lt 3 ]; then
 		speed=$((speed + 1))
-	elif [ "${speeda}" = 'down' ] && [ "${speed}" > 0 ]; then
+	elif [ "${speeda}" = 'down' ] && [ "${speed}" -gt 0 ]; then
 		speed=$((speed - 1))
-	elif [ "${speeda}" = 'step' ] && [ "${speed}" < 3 ]; then
+	elif [ "${speeda}" = 'step' ] && [ "${speed}" -lt 3 ]; then
 		speed=$((speed + 1))
 	elif [ "${speeda}" = 'step' ] && [ "${speed}" = 3 ]; then
 		speed=0

--- a/ite-829x-ui
+++ b/ite-829x-ui
@@ -142,7 +142,7 @@ kblToggle() {
 		effect=$([ "${effecta}" != "" ] && echo "${effecta}" || echo "${effect}")
 	fi
 
-	kblSet $([ "${brightness}" != "" ] && echo "-bs ${brightness}") $([ "${speed}" != "" ] && echo "-s ${speed}") $([ "${effect}" != "" ] && echo "-e ${effect}") $([ "${reda}" != "" ] && echo "-r ${reda}") $([ "${greena}" != "" ] && echo "-g ${greena}") $([ "${bluea}" != "" ] && echo "-b ${bluea}")
+	kblSet "$([ "${brightness}" != "" ] && echo "-bs ${brightness}")" "$([ "${speed}" != "" ] && echo "-s ${speed}")" "$([ "${effect}" != "" ] && echo "-e ${effect}")" "$([ "${reda}" != "" ] && echo "-r ${reda}")" "$([ "${greena}" != "" ] && echo "-g ${greena}")" "$([ "${bluea}" != "" ] && echo "-b ${bluea}")"
 }
 
 guiBrightness() {


### PR DESCRIPTION
Ran a full shellcheck report on the bash script and implemented most of the suggested changes.

Branches off of #1.

Remaining reports:

 - [SC2034]

   > `warning`: `arg` appears unused. Verify use (or `export` if used externally).

 - [SC2292]

   > `style`: Prefer `[[ ]]` over `[ ]` for tests in Bash/Ksh.

 - [SC2312]

   > `info`: Consider invoking this command separately to avoid masking its return value (or use `|| true` to ignore).

[SC2034]: https://www.shellcheck.net/wiki/SC2034
[SC2292]: https://www.shellcheck.net/wiki/SC2292
[SC2312]: https://www.shellcheck.net/wiki/SC2312